### PR TITLE
feat: get default WP block attributes

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -26,6 +26,13 @@ class Block implements BlockInterface
    */
   public array $classes;
 
+  /**
+   * Array of native Wordpress block HTML attributes. Can be added to the block
+   * @var array
+   */
+  protected array $blockAttributes;
+
+
   public function __construct()
   {
     if (is_admin()) {
@@ -33,6 +40,7 @@ class Block implements BlockInterface
     }
 
     $this->classes = $this->getClasses();
+    $this->blockAttributes = $this->getWpAttributes();
   }
 
   /**
@@ -79,6 +87,15 @@ class Block implements BlockInterface
 
   public static function display(): void
   {
+  }
+
+  private static function getWpAttributes(): array
+  {
+    $attrString = get_block_wrapper_attributes();
+    $attrArray = current((array) new \SimpleXMLElement("<element " . $attrString. " />"));
+    $attrArray['raw'] = $attrString;
+
+    return $attrArray;
   }
 
   private static function getBlockNameFromDir(): string


### PR DESCRIPTION
This allows you to get the default wp block attributes in the template.
It was tricky to do as main function returns string with attributes.
example: `string(39) “class=”wp-block-giantpeach-testimonial””`

I had to keep acf in mind too https://www.advancedcustomfields.com/resources/acf-blocks-using-get_block_wrapper_attributes/
Wp by default is adding the styles, so there is no need to render it in the admin.

I managed to split it into chunks and use it as an array with keys.

There are 2 ways to use it in the template.
First by creating empty element and passing raw string directly into it like so:

```
<div {{ not isAdmin ? blockAttributes.raw | raw }}>
    ... content ...
</div>
```


Second option is to add it to class attribute by key:
```
<section class="{{ classes.block.name }} {{ classes.block.name }} {{ not isAdmin ? blockAttributes.class }} some-other-custom-class">
    ... content ...
</div>
```


I think second option is better as we don't have to create additional div as a wrapper and we have more control over different attributes. Because of these flexibility I decided to use this attributes individually per block, rather than using it globally as a wrapper for every block